### PR TITLE
Improved SFTP file UTC time handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,98 @@
+# http://EditorConfig.org
+# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+
+# top-most EditorConfig file
+root = true
+
+# Code files
+[*.{cs,csx,scs,sql,vb,vbx}]
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Xml and Json files
+[*.{xml,xsd,csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct,json}]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Dotnet code style settings:
+[*.{cs,scs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:none
+dotnet_style_collection_initializer = true:none
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# CSharp code style settings:
+[*.{cs,scs}]
+# Never prefer "var"
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:none
+
+# Prefer method-like constructs to have an expression-body
+csharp_style_expression_bodied_methods = true:none
+csharp_style_expression_bodied_constructors = true:none
+csharp_style_expression_bodied_operators = true:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false

--- a/src/Renci.SshNet.Tests/Classes/BaseClientTest_Disconnected_KeepAliveInterval_NotNegativeOne.cs
+++ b/src/Renci.SshNet.Tests/Classes/BaseClientTest_Disconnected_KeepAliveInterval_NotNegativeOne.cs
@@ -14,7 +14,6 @@ namespace Renci.SshNet.Tests.Classes
         private BaseClient _client;
         private ConnectionInfo _connectionInfo;
         private TimeSpan _keepAliveInterval;
-        private int _keepAliveCount;
 
         [TestInitialize]
         public void Setup()
@@ -38,7 +37,6 @@ namespace Renci.SshNet.Tests.Classes
         {
             _connectionInfo = new ConnectionInfo("host", "user", new PasswordAuthenticationMethod("user", "pwd"));
             _keepAliveInterval = TimeSpan.FromMilliseconds(50d);
-            _keepAliveCount = 0;
         }
 
         private void CreateMocks()

--- a/src/Renci.SshNet.Tests/Classes/ClientAuthenticationTest_Success_MultiList_PartialSuccessLimitReachedFollowedBySuccessInAlternateBranch.cs
+++ b/src/Renci.SshNet.Tests/Classes/ClientAuthenticationTest_Success_MultiList_PartialSuccessLimitReachedFollowedBySuccessInAlternateBranch.cs
@@ -35,7 +35,6 @@ namespace Renci.SshNet.Tests.Classes
     {
         private int _partialSuccessLimit;
         private ClientAuthentication _clientAuthentication;
-        private SshAuthenticationException _actualException;
 
         protected override void SetupData()
         {

--- a/src/Renci.SshNet.Tests/Classes/Common/BigIntegerTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Common/BigIntegerTest.cs
@@ -1506,10 +1506,12 @@ namespace Renci.SshNet.Tests.Classes.Common
             Assert.AreEqual("0", a.ToString(), "#4");
 
             a = new BigInteger();
+#pragma warning disable CS1718 // Comparison made to same variable
             Assert.AreEqual(true, a == a, "#5");
 
             a = new BigInteger();
             Assert.AreEqual(false, a < a, "#6");
+#pragma warning restore CS1718 // Comparison made to same variable
 
             a = new BigInteger();
             Assert.AreEqual(true, a < 10L, "#7");

--- a/src/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelExtendedDataMessageTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/Messages/Connection/ChannelExtendedDataMessageTest.cs
@@ -30,7 +30,7 @@ namespace Renci.SshNet.Tests.Classes.Messages.Connection
         [Ignore] // placeholder
         public void ChannelExtendedDataMessageConstructorTest1()
         {
-            uint localChannelNumber = 0; // TODO: Initialize to an appropriate value
+            //uint localChannelNumber = 0; // TODO: Initialize to an appropriate value
             //ChannelExtendedDataMessage target = new ChannelExtendedDataMessage(localChannelNumber, null, null);
             Assert.Inconclusive("TODO: Implement code to verify target");
         }

--- a/src/Renci.SshNet.Tests/Classes/SftpClientTest.cs
+++ b/src/Renci.SshNet.Tests/Classes/SftpClientTest.cs
@@ -942,7 +942,9 @@ namespace Renci.SshNet.Tests.Classes
             SftpClient target = new SftpClient(connectionInfo); // TODO: Initialize to an appropriate value
             string path = string.Empty; // TODO: Initialize to an appropriate value
             DateTime lastAccessTime = new DateTime(); // TODO: Initialize to an appropriate value
+#pragma warning disable CS0618 // Type or member is obsolete
             target.SetLastAccessTime(path, lastAccessTime);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Inconclusive("A method that does not return a value cannot be verified.");
         }
 
@@ -957,7 +959,9 @@ namespace Renci.SshNet.Tests.Classes
             SftpClient target = new SftpClient(connectionInfo); // TODO: Initialize to an appropriate value
             string path = string.Empty; // TODO: Initialize to an appropriate value
             DateTime lastAccessTimeUtc = new DateTime(); // TODO: Initialize to an appropriate value
+#pragma warning disable CS0618 // Type or member is obsolete
             target.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Inconclusive("A method that does not return a value cannot be verified.");
         }
 
@@ -972,7 +976,9 @@ namespace Renci.SshNet.Tests.Classes
             SftpClient target = new SftpClient(connectionInfo); // TODO: Initialize to an appropriate value
             string path = string.Empty; // TODO: Initialize to an appropriate value
             DateTime lastWriteTime = new DateTime(); // TODO: Initialize to an appropriate value
+#pragma warning disable CS0618 // Type or member is obsolete
             target.SetLastWriteTime(path, lastWriteTime);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Inconclusive("A method that does not return a value cannot be verified.");
         }
 
@@ -987,7 +993,9 @@ namespace Renci.SshNet.Tests.Classes
             SftpClient target = new SftpClient(connectionInfo); // TODO: Initialize to an appropriate value
             string path = string.Empty; // TODO: Initialize to an appropriate value
             DateTime lastWriteTimeUtc = new DateTime(); // TODO: Initialize to an appropriate value
+#pragma warning disable CS0618 // Type or member is obsolete
             target.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Inconclusive("A method that does not return a value cannot be verified.");
         }
 

--- a/src/Renci.SshNet/Sftp/SftpFile.cs
+++ b/src/Renci.SshNet/Sftp/SftpFile.cs
@@ -99,11 +99,11 @@ namespace Renci.SshNet.Sftp
         {
             get
             {
-                return Attributes.LastAccessTime.ToUniversalTime();
+                return Attributes.LastAccessTimeUtc;
             }
             set
             {
-                Attributes.LastAccessTime = value.ToLocalTime();
+                Attributes.LastAccessTimeUtc = value;
             }
         }
 
@@ -117,11 +117,11 @@ namespace Renci.SshNet.Sftp
         {
             get
             {
-                return Attributes.LastWriteTime.ToUniversalTime();
+                return Attributes.LastWriteTimeUtc;
             }
             set
             {
-                Attributes.LastWriteTime = value.ToLocalTime();
+                Attributes.LastWriteTimeUtc = value;
             }
         }
 

--- a/src/Renci.SshNet/Sftp/SftpFileAttributes.cs
+++ b/src/Renci.SshNet/Sftp/SftpFileAttributes.cs
@@ -11,7 +11,7 @@ namespace Renci.SshNet.Sftp
     /// </summary>
     public class SftpFileAttributes
     {
-        #region Bitmask constats
+        #region Bitmask constants
 
         private const uint S_IFMT = 0xF000; //  bitmask for the file type bitfields
 
@@ -60,8 +60,8 @@ namespace Renci.SshNet.Sftp
         private bool _isGroupIDBitSet;
         private bool _isStickyBitSet;
 
-        private readonly DateTime _originalLastAccessTime;
-        private readonly DateTime _originalLastWriteTime;
+        private readonly DateTime _originalLastAccessTimeUtc;
+        private readonly DateTime _originalLastWriteTimeUtc;
         private readonly long _originalSize;
         private readonly int _originalUserId;
         private readonly int _originalGroupId;
@@ -70,12 +70,12 @@ namespace Renci.SshNet.Sftp
 
         internal bool IsLastAccessTimeChanged
         {
-            get { return _originalLastAccessTime != LastAccessTime; }
+            get { return _originalLastAccessTimeUtc != LastAccessTimeUtc; }
         }
 
         internal bool IsLastWriteTimeChanged
         {
-            get { return _originalLastWriteTime != LastWriteTime; }
+            get { return _originalLastWriteTimeUtc != LastWriteTimeUtc; }
         }
 
         internal bool IsSizeChanged
@@ -104,20 +104,58 @@ namespace Renci.SshNet.Sftp
         }
 
         /// <summary>
-        /// Gets or sets the time the current file or directory was last accessed.
+        /// Gets or sets the local time the current file or directory was last accessed.
         /// </summary>
         /// <value>
-        /// The time that the current file or directory was last accessed.
+        /// The local time that the current file or directory was last accessed.
         /// </value>
-        public DateTime LastAccessTime { get; set; }
+        public DateTime LastAccessTime
+        {
+            get
+            {
+                return ToLocalTime(this.LastAccessTimeUtc);
+            }
+
+            set
+            {
+                this.LastAccessTimeUtc = ToUniversalTime(value);
+            }
+        }
 
         /// <summary>
-        /// Gets or sets the time when the current file or directory was last written to.
+        /// Gets or sets the local time when the current file or directory was last written to.
         /// </summary>
         /// <value>
-        /// The time the current file was last written.
+        /// The local time the current file was last written.
         /// </value>
-        public DateTime LastWriteTime { get; set; }
+        public DateTime LastWriteTime
+        {
+            get
+            {
+                return ToLocalTime(this.LastWriteTimeUtc);
+            }
+
+            set
+            {
+                this.LastWriteTimeUtc = ToUniversalTime(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the UTC time the current file or directory was last accessed.
+        /// </summary>
+        /// <value>
+        /// The UTC time that the current file or directory was last accessed.
+        /// </value>
+        public DateTime LastAccessTimeUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC time when the current file or directory was last written to.
+        /// </summary>
+        /// <value>
+        /// The UTC time the current file was last written.
+        /// </value>
+        public DateTime LastWriteTimeUtc { get; set; }
 
         /// <summary>
         /// Gets or sets the size, in bytes, of the current file.
@@ -397,8 +435,8 @@ namespace Renci.SshNet.Sftp
 
         internal SftpFileAttributes(DateTime lastAccessTime, DateTime lastWriteTime, long size, int userId, int groupId, uint permissions, IDictionary<string, string> extensions)
         {
-            LastAccessTime = _originalLastAccessTime = lastAccessTime;
-            LastWriteTime = _originalLastWriteTime = lastWriteTime;
+            LastAccessTimeUtc = _originalLastAccessTimeUtc = ToUniversalTime(lastAccessTime);
+            LastWriteTimeUtc = _originalLastWriteTimeUtc = ToUniversalTime(lastWriteTime);
             Size = _originalSize = size;
             UserId = _originalUserId = userId;
             GroupId = _originalGroupId = groupId;
@@ -491,9 +529,9 @@ namespace Renci.SshNet.Sftp
 
             if (IsLastAccessTimeChanged || IsLastWriteTimeChanged)
             {
-                var time = (uint)(LastAccessTime.ToFileTime() / 10000000 - 11644473600);
+                var time = (uint)(LastAccessTimeUtc.ToFileTimeUtc() / 10000000 - 11644473600);
                 stream.Write(time);
-                time = (uint)(LastWriteTime.ToFileTime() / 10000000 - 11644473600);
+                time = (uint)(LastWriteTimeUtc.ToFileTimeUtc() / 10000000 - 11644473600);
                 stream.Write(time);
             }
 
@@ -544,10 +582,12 @@ namespace Renci.SshNet.Sftp
 
             if ((flag & 0x00000008) == 0x00000008)   //  SSH_FILEXFER_ATTR_ACMODTIME
             {
+                // The incoming times are "Unix times", so they're already in UTC.  We need to preserve that
+                // to avoid losing information in a local time conversion during the "fall back" hour in DST.
                 var time = stream.ReadUInt32();
-                accessTime = DateTime.FromFileTime((time + 11644473600) * 10000000);
+                accessTime = DateTime.FromFileTimeUtc((time + 11644473600) * 10000000);
                 time = stream.ReadUInt32();
-                modifyTime = DateTime.FromFileTime((time + 11644473600) * 10000000);
+                modifyTime = DateTime.FromFileTimeUtc((time + 11644473600) * 10000000);
             }
 
             if ((flag & 0x80000000) == 0x80000000)   //  SSH_FILEXFER_ATTR_EXTENDED
@@ -571,6 +611,38 @@ namespace Renci.SshNet.Sftp
             {
                 return FromBytes(stream);
             }
+        }
+
+        internal static DateTime ToLocalTime(DateTime value)
+        {
+            DateTime result;
+
+            if (value == DateTime.MinValue)
+            {
+                result = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Local);
+            }
+            else
+            {
+                result = value.ToLocalTime();
+            }
+
+            return result;
+        }
+
+        internal static DateTime ToUniversalTime(DateTime value)
+        {
+            DateTime result;
+
+            if (value == DateTime.MinValue)
+            {
+                result = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
+            }
+            else
+            {
+                result = value.ToUniversalTime();
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
I changed SftpFileAttributes to preserve the last access and modified times as UTC values rather than always forcing a local conversion.  This primarily affected the FromBytes(SshDataStream) method, but the changes cascade out from there to make sure that SftpFileAttributes and SftpFile can be used without ever forcing a (potentially lossy) conversion to local time.  In the SSH data stream the atime and mtime values are "Unix times" in seconds, so they're already in UTC.  We need to preserve that fact by returning and storing DateTime values with Kind == Utc.

Previously, the code called DateTime.FromFileTime.  Internally, FromFileTime calls DateTime.ToLocalTime(), which is a lossy function.  For example, any local time >= 1am and < 2am during the "fall back" hour of a daylight saving time shift in the fall could have come from two different UTC times.  Avoiding this ambiguity is why file systems store times in UTC, so the SFTP classes need to preserve UTC times too.  Here's a simple example to see this in VS's C# interactive window:

```
TimeZoneInfo central = TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
DateTime first = new DateTime(2017, 11, 5, 6, 0, 0, DateTimeKind.Utc);
DateTime second = new DateTime(2017, 11, 5, 7, 0, 0, DateTimeKind.Utc);
Console.WriteLine(TimeZoneInfo.ConvertTimeFromUtc(first, central));
Console.WriteLine(TimeZoneInfo.ConvertTimeFromUtc(second, central));
// Both UTC times convert to the same local time: 11/5/2017 1:00:00 AM
```

.NET also has an issue where it caches the current local time zone offset, so it can incorrectly calculate local times after a DST shift if nothing has called CultureInfo.ClearCachedData or TimeZoneInfo.ClearCachedData.  This is discussed more at [https://stackoverflow.com/a/297189/1882616](https://stackoverflow.com/a/297189/1882616), and it can be a big problem in long-running services if not handled correctly.  By making SSH.NET internally preserve UTC times correctly, the library can be immune to problems with DST shifts for callers that only work with UTC times.

I also cleaned up some warnings in the unit tests and added an .editorconfig file so VS 2017 will know to use spaces for indentation in this solution (even though my global preference is set to tabs).